### PR TITLE
Add custom link text option

### DIFF
--- a/src/ContentElement/LinkTeaserElement.php
+++ b/src/ContentElement/LinkTeaserElement.php
@@ -24,6 +24,7 @@ use Contao\Input;
 use Contao\PageModel;
 use Contao\StringUtil;
 use Contao\System;
+use HeimrichHannot\ContaoTeaserBundle\DataContainer\ContentListener;
 
 class LinkTeaserElement extends ContentText
 {
@@ -77,7 +78,11 @@ class LinkTeaserElement extends ContentText
     {
         global $objPage;
 
-        $this->label = $GLOBALS['TL_LANG']['MSC']['linkteaser']['teaserlinktext'][$this->teaserLinkText];
+        if (ContentListener::LINK_TEXT_CUSTOM === $this->teaserLinkText) {
+            $this->label = $this->linkTitle;
+        } else {
+            $this->label = $GLOBALS['TL_LANG']['MSC']['linkteaser']['teaserlinktext'][$this->teaserLinkText];
+        }
         $this->setLink(is_array($this->label) ? $this->label[0] : $this->label);
 
         switch ($this->source)

--- a/src/DataContainer/ContentListener.php
+++ b/src/DataContainer/ContentListener.php
@@ -66,7 +66,7 @@ class ContentListener
             $arrOptions[$strKey] = $strTitle;
         }
 
-        $options['Vordefiniert'] = $arrOptions;
+        $options[$GLOBALS['TL_LANG']['MSC']['linkteaser']['predefinedLinkText']] = $arrOptions;
 
         return $options;
     }
@@ -74,7 +74,7 @@ class ContentListener
     public function onLoadCallback(DataContainer $dc)
     {
         $contentModel = ContentModel::findByPk($dc->id);
-        if (!$contentModel->type === LinkTeaserElement::TYPE) {
+        if ($contentModel->type !== LinkTeaserElement::TYPE) {
             return;
         }
 

--- a/src/DataContainer/ContentListener.php
+++ b/src/DataContainer/ContentListener.php
@@ -23,6 +23,8 @@ use HeimrichHannot\ContaoTeaserBundle\ContentElement\LinkTeaserElement;
 
 class ContentListener
 {
+    const LINK_TEXT_CUSTOM = 'custom';
+
     /**
      * @var ContaoFramework
      */
@@ -39,7 +41,9 @@ class ContentListener
 
     public function getTeaserLinkText()
     {
-        $arrOptions = [];
+        $arrOptions = [
+            static::LINK_TEXT_CUSTOM => $GLOBALS['TL_LANG']['MSC']['linkteaser']['customLinkText'],
+        ];
 
         $arrTitles = $GLOBALS['TL_LANG']['MSC']['linkteaser']['teaserlinktext'];
 
@@ -47,6 +51,10 @@ class ContentListener
         {
             return $arrOptions;
         }
+
+        $options = [$GLOBALS['TL_LANG']['MSC']['linkteaser']['customLinkText'] => $arrOptions];
+
+        $arrOptions = [];
 
         foreach ($arrTitles as $strKey => $strTitle)
         {
@@ -58,10 +66,12 @@ class ContentListener
             $arrOptions[$strKey] = $strTitle;
         }
 
-        return $arrOptions;
+        $options['Vordefiniert'] = $arrOptions;
+
+        return $options;
     }
 
-    public function onLoad(DataContainer $dc)
+    public function onLoadCallback(DataContainer $dc)
     {
         $contentModel = ContentModel::findByPk($dc->id);
         if (!$contentModel->type === LinkTeaserElement::TYPE) {
@@ -74,6 +84,7 @@ class ContentListener
         $dca['fields']['target']['load_callback'][] = [__CLASS__, 'setTargetFlags'];
         $dca['fields']['article']['label'] = &$GLOBALS['TL_LANG']['tl_content']['articleId'];
         $dca['fields']['article']['eval']['submitOnChange'] = false;
+        $dca['fields']['linkTitle']['label'][1] = $GLOBALS['TL_LANG']['tl_content']['linkTitle']['huh_teaser'];
     }
 
     /**

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -8,19 +8,23 @@
  * @license http://www.gnu.org/licences/lgpl-3.0.html LGPL
  */
 
+use HeimrichHannot\ContaoTeaserBundle\ContentElement\LinkTeaserElement;
+use HeimrichHannot\ContaoTeaserBundle\DataContainer\ContentListener;
+
 $dc = &$GLOBALS['TL_DCA']['tl_content'];
 
-$dc['config']['onload_callback'][] = [HeimrichHannot\ContaoTeaserBundle\DataContainer\ContentListener::class, 'onLoad'];
+$dc['config']['onload_callback'][] = [ContentListener::class, 'onLoadCallback'];
 
 /**
  * Selector
  */
-array_insert($dc['palettes']['__selector__'], 0, 'source');
+$dc['palettes']['__selector__'][] = 'teaserLinkText';
+$dc['palettes']['__selector__'][] = 'source';
 
 /**
  * Palettes
  */
-$dc['palettes'][\HeimrichHannot\ContaoTeaserBundle\ContentElement\LinkTeaserElement::TYPE] =
+$dc['palettes'][LinkTeaserElement::TYPE] =
     '{type_legend},type,headline;
     {teaser_legend},source,teaserLinkText,teaserLinkCssClass,teaserLinkBehaviour,teaserContentTemplate,target;
     {text_legend},text;
@@ -38,6 +42,7 @@ $dc['subpalettes']['source_file']     = 'fileSRC';
 $dc['subpalettes']['source_download'] = 'fileSRC';
 $dc['subpalettes']['source_article']  = 'article';
 $dc['subpalettes']['source_external'] = 'url';
+$dc['subpalettes']['teaserLinkText_custom'] = 'linkTitle';
 
 
 /**
@@ -46,11 +51,11 @@ $dc['subpalettes']['source_external'] = 'url';
 $arrFields = [
     'source'                => [
         'label'            => &$GLOBALS['TL_LANG']['tl_content']['source'],
-        'default'          => \HeimrichHannot\ContaoTeaserBundle\ContentElement\LinkTeaserElement::SOURCE_PAGE,
+        'default'          => LinkTeaserElement::SOURCE_PAGE,
         'exclude'          => true,
         'filter'           => true,
         'inputType'        => 'radio',
-        'options_callback' => [HeimrichHannot\ContaoTeaserBundle\DataContainer\ContentListener::class, 'getSourceOptions'],
+        'options_callback' => [ContentListener::class, 'getSourceOptions'],
         'reference'        => &$GLOBALS['TL_LANG']['tl_content']['reference']['source'],
         'eval'             => ['submitOnChange' => true, 'helpwizard' => true, 'mandatory' => true],
         'sql'              => "varchar(12) NOT NULL default ''",
@@ -70,17 +75,21 @@ $arrFields = [
         'inputType'     => 'fileTree',
         'eval'          => ['filesOnly' => true, 'fieldType' => 'radio', 'mandatory' => true, 'tl_class' => 'clr'],
         'load_callback' => [
-            [HeimrichHannot\ContaoTeaserBundle\DataContainer\ContentListener::class, 'setFileSrcFlags'],
+            [ContentListener::class, 'setFileSrcFlags'],
         ],
         'sql'           => "binary(16) NULL",
     ],
     'teaserLinkText'        => [
         'label'            => &$GLOBALS['TL_LANG']['tl_content']['teaserLinkText'],
-        'exclude'          => true,
-        'search'           => true,
+        'exclude'          => false,
+        'search'           => false,
         'inputType'        => 'select',
-        'options_callback' => [HeimrichHannot\ContaoTeaserBundle\DataContainer\ContentListener::class, 'getTeaserLinkText'],
-        'eval'             => ['tl_class' => 'w50 clr', 'maxlength' => 64],
+        'options_callback' => [ContentListener::class, 'getTeaserLinkText'],
+        'eval'             => [
+            'tl_class' => 'w50 clr',
+            'maxlength' => 64,
+            'submitOnChange' => true,
+        ],
         'sql'              => "varchar(64) NOT NULL default ''",
     ],
     'teaserLinkCssClass'    => [
@@ -96,9 +105,9 @@ $arrFields = [
         'inputType' => 'select',
         'default'   => 'default',
         'options'   => [
-            \HeimrichHannot\ContaoTeaserBundle\ContentElement\LinkTeaserElement::LINK_BEHAVIOUR_SHOW_LINK,
-            \HeimrichHannot\ContaoTeaserBundle\ContentElement\LinkTeaserElement::LINK_BEHAVIOUR_LINK_ALL,
-            \HeimrichHannot\ContaoTeaserBundle\ContentElement\LinkTeaserElement::LINK_BEHAVIOUR_HIDE_LINK
+            LinkTeaserElement::LINK_BEHAVIOUR_SHOW_LINK,
+            LinkTeaserElement::LINK_BEHAVIOUR_LINK_ALL,
+            LinkTeaserElement::LINK_BEHAVIOUR_HIDE_LINK
         ],
         'reference' => &$GLOBALS['TL_LANG']['tl_content']['reference']['teaserLinkBehaviour'],
         'eval'      => ['tl_class' => 'w50 clr'],
@@ -108,7 +117,7 @@ $arrFields = [
         'label'            => &$GLOBALS['TL_LANG']['tl_content']['teaserContentTemplate'],
         'exclude'          => true,
         'inputType'        => 'select',
-        'options_callback' => [HeimrichHannot\ContaoTeaserBundle\DataContainer\ContentListener::class, 'getTeaserContentTemplates'],
+        'options_callback' => [ContentListener::class, 'getTeaserContentTemplates'],
         'eval'             => ['tl_class' => 'w50', 'includeBlankOption' => true],
         'sql'              => "varchar(64) NOT NULL default ''",
     ],

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -81,7 +81,7 @@ $arrFields = [
     ],
     'teaserLinkText'        => [
         'label'            => &$GLOBALS['TL_LANG']['tl_content']['teaserLinkText'],
-        'exclude'          => false,
+        'exclude'          => true,
         'search'           => false,
         'inputType'        => 'select',
         'options_callback' => [ContentListener::class, 'getTeaserLinkText'],

--- a/src/Resources/contao/languages/de/default.php
+++ b/src/Resources/contao/languages/de/default.php
@@ -29,6 +29,7 @@ $GLOBALS['TL_LANG']['MSC']['linkteaser']['externalMailTitle'] = 'E-Mail schreibe
 $GLOBALS['TL_LANG']['MSC']['linkteaser']['externalLinkTitle'] = 'Seite besuchen: %s';
 
 $GLOBALS['TL_LANG']['MSC']['linkteaser']['customLinkText'] = 'Benutzerdefiniert';
+$GLOBALS['TL_LANG']['MSC']['linkteaser']['predefinedLinkText'] = 'Vordefiniert';
 
 
 /**

--- a/src/Resources/contao/languages/de/default.php
+++ b/src/Resources/contao/languages/de/default.php
@@ -28,6 +28,8 @@ $GLOBALS['TL_LANG']['MSC']['linkteaser']['articleTitle'] = 'Artikel aufrufen: %s
 $GLOBALS['TL_LANG']['MSC']['linkteaser']['externalMailTitle'] = 'E-Mail schreiben an: %s';
 $GLOBALS['TL_LANG']['MSC']['linkteaser']['externalLinkTitle'] = 'Seite besuchen: %s';
 
+$GLOBALS['TL_LANG']['MSC']['linkteaser']['customLinkText'] = 'Benutzerdefiniert';
+
 
 /**
  * Content elements

--- a/src/Resources/contao/languages/de/tl_content.php
+++ b/src/Resources/contao/languages/de/tl_content.php
@@ -29,6 +29,9 @@ $GLOBALS['TL_LANG']['tl_content']['teaserLinkBehaviour'][1] = 'Steuern Sie das v
 $GLOBALS['TL_LANG']['tl_content']['teaserContentTemplate'][0] = 'Teaser-Template überschreiben';
 $GLOBALS['TL_LANG']['tl_content']['teaserContentTemplate'][1] = 'Überschreiben Sie hier das Template für den Inhalt des Teasers.';
 
+$GLOBALS['TL_LANG']['tl_content']['linkTitle']['huh_teaser'] = 'Geben Sie hier einen benutzerdefinierten Weiterlesen-Link Text an.';
+
+
 /**
  * Legends
  */

--- a/src/Resources/contao/languages/en/default.php
+++ b/src/Resources/contao/languages/en/default.php
@@ -28,6 +28,9 @@ $GLOBALS['TL_LANG']['MSC']['linkteaser']['articleTitle'] = 'Read article: %s';
 $GLOBALS['TL_LANG']['MSC']['linkteaser']['externalMailTitle'] = 'Write e-mail to: %s';
 $GLOBALS['TL_LANG']['MSC']['linkteaser']['externalLinkTitle'] = 'Visit page: %s';
 
+$GLOBALS['TL_LANG']['MSC']['linkteaser']['customLinkText'] = 'Custom';
+$GLOBALS['TL_LANG']['MSC']['linkteaser']['predefinedLinkText'] = 'Predefined';
+
 
 /**
  * Content elements

--- a/src/Resources/contao/languages/pl/default.php
+++ b/src/Resources/contao/languages/pl/default.php
@@ -19,6 +19,8 @@ $GLOBALS['TL_LANG']['MSC']['linkteaser']['articleTitle']      = 'Pokaż artykuł
 $GLOBALS['TL_LANG']['MSC']['linkteaser']['externalMailTitle'] = 'Napisz wiadomość e-mail do: %s';
 $GLOBALS['TL_LANG']['MSC']['linkteaser']['externalLinkTitle'] = 'Odwiedź stronę: %s';
 
+$GLOBALS['TL_LANG']['MSC']['linkteaser']['customLinkText'] = 'Zdefiniowany przez użytkownia';
+$GLOBALS['TL_LANG']['MSC']['linkteaser']['predefinedLinkText'] = 'Wstępnie zdefiniowany';
 
 /**
  * Content elements


### PR DESCRIPTION
This PR add a custom link text option. This will also fix #8 .

Changelog:
- Added: custom-Option to teaserLinkText field which will show a user input field to set a custom link text